### PR TITLE
fix paintbox speed

### DIFF
--- a/src/draw_mask.c
+++ b/src/draw_mask.c
@@ -45,8 +45,6 @@ draw_mask(VipsImage *image, VipsPel *ink, VipsImage *mask, int x, int y)
 	VipsRect mask_clip;
 
 	if (vips_check_coding_noneorlabq("draw_mask", image) ||
-		vips_image_inplace(image) ||
-		vips_image_wio_input(mask) ||
 		vips_check_mono("draw_mask", mask) ||
 		vips_check_uncoded("draw_mask", mask) ||
 		vips_check_format("draw_mask", mask, VIPS_FORMAT_UCHAR))

--- a/src/paintbox.c
+++ b/src/paintbox.c
@@ -255,6 +255,9 @@ paintbox_make_brush(Paintbox *paintbox)
 		NULL))
 		return FALSE;
 
+	// force to memory ... don't do this in draw_mask, it'd be very slow
+	(void) vips_image_wio_input(mask);
+
 	paintbox->mask = mask;
 
 	return TRUE;
@@ -280,7 +283,8 @@ paintbox_make_text(Paintbox *paintbox, const char *text)
 	VIPS_UNREF(o);
 
 	VipsImage *mask;
-	if (vips_text(&mask, text, "font", font, NULL))
+	if (vips_text(&mask, text, "font", font, NULL) ||
+		vips_image_wio_input(mask))
 		return FALSE;
 
 	paintbox->mask = mask;


### PR DESCRIPTION
When drawing wide lines, draw_line was calling vips_image_inplace() and vips_image_wio_input() for each pixel. This triggered invalidate, and when the operation cache was full of cached getpoint() calls from the info bar, made drawing very slow.

This might fix the crashes with paint + infobar enabled too.